### PR TITLE
Remove invalid dependency to a byproduct of linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ out
 
 # bootstrap folder for spl builds
 /.bootstrap/
+
+# version tag files created by installer
+/v*

--- a/cmake/spl.cmake
+++ b/cmake/spl.cmake
@@ -35,10 +35,6 @@ if(BUILD_KIT STREQUAL prod)
         list(APPEND LINK_TARGET_DEPENDS ${VARIANT_LINKER_FILE})
     endif()
 
-    if(LINK_HEX_FILE)
-        list(APPEND LINK_TARGET_DEPENDS ${LINK_HEX_FILE})
-    endif()
-
     # create executable
     add_executable(${LINK_TARGET_NAME} ${LINK_TARGET_DEPENDS})
     target_compile_options(${LINK_TARGET_NAME} PRIVATE ${VARIANT_ADDITIONAL_LINK_FLAGS})


### PR DESCRIPTION
No idea why these lines where added but they are simply wrong. The link target, that creates the hex file, cannot depend on it. This is a deadlock when enabling the hex extension and deleting the hex file.