### PR TITLE
expand kconfig values and environment variables within kconfig

### DIFF
--- a/cmake/spl.cmake
+++ b/cmake/spl.cmake
@@ -8,6 +8,12 @@ if(PIP_INSTALL_REQUIREMENTS)
     run_pip("${PIP_INSTALL_REQUIREMENTS}" $ENV{SPL_PIP_REPOSITORY} $ENV{SPL_PIP_TRUSTED_HOST})
 endif() 
 
+# set SPL relevant variables as environment variables, can easily be extended in CMakeLists.txt of project before including SPL core (used for KConfig variable expansion).
+list(APPEND ENVVARS FLAVOR SUBSYSTEM VARIANT BUILD_KIT BINARY_BASENAME CMAKE_SOURCE_DIR)
+foreach(ENVVAR IN LISTS ENVVARS)
+    set(ENV{${ENVVAR}} "${${ENVVAR}}")
+endforeach()
+
 # Include and run KConfig
 include(${CMAKE_CURRENT_LIST_DIR}/kconfig.cmake)
 

--- a/doc/build.md
+++ b/doc/build.md
@@ -23,3 +23,12 @@ cd <Your root directory of repository>
 ## Binary Location
 
 After the build all binaries can be found under `/build/{variant}`.
+
+
+## Configuration
+
+Configuration is done using KConfig. The target `Configuration` will open gui-config, a GUI tool to configure KConfig.
+Within this configuration a variable expansion is possible for `string` configs:
+
+* KConfig variables get replaced like: `${VARIABLE_NAME}`, e.g. `${SPL_RELEASE_VERSION}`
+* environment variables get replaced with: `${ENV:VARIABLE_NAME}`, e.g. `${ENV:VARIANT}`  (VARIANT is exposed as environment variable, other internal variables as well)


### PR DESCRIPTION
Inside KConfig configurations a variable expansion is now possible. It works for both: other KConfig values as reference or replacing environment variables.

* KConfig variables get replaced like: `${VARIABLE_NAME}`, e.g. `${SPL_RELEASE_VERSION}`
* environment variables get replaced with: `${ENV:VARIABLE_NAME}`, e.g. `${ENV:VARIANT}`  (VARIANT is exposed as environment variable, other internal variables as well)