### PR TITLE
fix: coverage report is empty

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -311,7 +311,7 @@ macro(_spl_add_test_suite PROD_SRC TEST_SOURCES)
     set(COV_OUT_JSON coverage.json)
     add_custom_command(
         OUTPUT ${COV_OUT_JSON}
-        COMMAND gcovr --root ${CMAKE_SOURCE_DIR} --filter ${CMAKE_CURRENT_LIST_DIR}/src --json --output ${COV_OUT_JSON} ${GCOVR_ADDITIONAL_OPTIONS} ${CMAKE_CURRENT_BINARY_DIR}
+        COMMAND gcovr --root ${CMAKE_SOURCE_DIR} --json --output ${COV_OUT_JSON} ${GCOVR_ADDITIONAL_OPTIONS} ${CMAKE_CURRENT_BINARY_DIR}
         DEPENDS ${TEST_OUT_JUNIT}
     )
 


### PR DESCRIPTION
I am writing tests for my legacy components. I have create a source file including the variant legacy `.c` file. The target to call `gcovr` for generating the coverage json file has a filter to only include coverage data for files inside the component `src` directory.
Because my component source file includes a file from the variant legacy directory, the coverage report is empty. The legacy file coverage data is not included in the report. 

This change removes the filter. I assume the purpose of the filter was to exclude coverage data for the test files. I checked and the test files are not compiled with `--coverage` so removing the filter shall not change the coverage reports for components not dealing with legacy includes.