### PR TITLE
Feature/include changelog and readme in docs

### DIFF
--- a/docs/about/_changelog.md
+++ b/docs/about/_changelog.md
@@ -1,0 +1,4 @@
+```{include} ../../CHANGELOG.md
+:relative-docs: docs/
+:relative-images:
+```

--- a/docs/about/_readme.md
+++ b/docs/about/_readme.md
@@ -1,0 +1,4 @@
+```{include} ../../README.md
+:relative-docs: docs/
+:relative-images:
+```

--- a/docs/about/index.rst
+++ b/docs/about/index.rst
@@ -1,4 +1,8 @@
 📄 About
 ********
 
-.. mdinclude:: ../../CHANGELOG.md
+.. toctree::
+    :maxdepth: 1
+
+    _readme.md
+    _changelog.md

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, sources_path.as_posix())
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "SPL Core"
-copyright = "2023, RMT"
+copyright = "2024, RMT"
 author = "RMT"
 release = "4.4.1"
 
@@ -22,8 +22,8 @@ release = "4.4.1"
 
 extensions = []
 
-# markdown to rst (m2r) config - @see https://pypi.org/project/m2r/
-extensions.append("m2r")
+# https://myst-parser.readthedocs.io/en/latest/intro.html
+extensions.append("myst_parser")
 
 # TODO: enable this extension when is is supported by readthedocs
 # draw.io config - @see https://pypi.org/project/sphinxcontrib-drawio/


### PR DESCRIPTION
M2R is no longer in active development. See [their GitHub](https://github.com/miyakogi/m2r) for reference.
Since we are having myst_parser in pyproject.toml, we can also utilize it to handle markdown files.