### PR TITLE
remove black dependency and reformat with ruff

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -137,53 +137,6 @@ files = [
 chardet = ">=3.0.2"
 
 [[package]]
-name = "black"
-version = "23.12.1"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "black-23.12.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e0aaf6041986767a5e0ce663c7a2f0e9eaf21e6ff87a5f95cbf3675bfd4c41d2"},
-    {file = "black-23.12.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c88b3711d12905b74206227109272673edce0cb29f27e1385f33b0163c414bba"},
-    {file = "black-23.12.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a920b569dc6b3472513ba6ddea21f440d4b4c699494d2e972a1753cdc25df7b0"},
-    {file = "black-23.12.1-cp310-cp310-win_amd64.whl", hash = "sha256:3fa4be75ef2a6b96ea8d92b1587dd8cb3a35c7e3d51f0738ced0781c3aa3a5a3"},
-    {file = "black-23.12.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8d4df77958a622f9b5a4c96edb4b8c0034f8434032ab11077ec6c56ae9f384ba"},
-    {file = "black-23.12.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:602cfb1196dc692424c70b6507593a2b29aac0547c1be9a1d1365f0d964c353b"},
-    {file = "black-23.12.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c4352800f14be5b4864016882cdba10755bd50805c95f728011bcb47a4afd59"},
-    {file = "black-23.12.1-cp311-cp311-win_amd64.whl", hash = "sha256:0808494f2b2df923ffc5723ed3c7b096bd76341f6213989759287611e9837d50"},
-    {file = "black-23.12.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:25e57fd232a6d6ff3f4478a6fd0580838e47c93c83eaf1ccc92d4faf27112c4e"},
-    {file = "black-23.12.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d9e13db441c509a3763a7a3d9a49ccc1b4e974a47be4e08ade2a228876500ec"},
-    {file = "black-23.12.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d1bd9c210f8b109b1762ec9fd36592fdd528485aadb3f5849b2740ef17e674e"},
-    {file = "black-23.12.1-cp312-cp312-win_amd64.whl", hash = "sha256:ae76c22bde5cbb6bfd211ec343ded2163bba7883c7bc77f6b756a1049436fbb9"},
-    {file = "black-23.12.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1fa88a0f74e50e4487477bc0bb900c6781dbddfdfa32691e780bf854c3b4a47f"},
-    {file = "black-23.12.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a4d6a9668e45ad99d2f8ec70d5c8c04ef4f32f648ef39048d010b0689832ec6d"},
-    {file = "black-23.12.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b18fb2ae6c4bb63eebe5be6bd869ba2f14fd0259bda7d18a46b764d8fb86298a"},
-    {file = "black-23.12.1-cp38-cp38-win_amd64.whl", hash = "sha256:c04b6d9d20e9c13f43eee8ea87d44156b8505ca8a3c878773f68b4e4812a421e"},
-    {file = "black-23.12.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3e1b38b3135fd4c025c28c55ddfc236b05af657828a8a6abe5deec419a0b7055"},
-    {file = "black-23.12.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4f0031eaa7b921db76decd73636ef3a12c942ed367d8c3841a0739412b260a54"},
-    {file = "black-23.12.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97e56155c6b737854e60a9ab1c598ff2533d57e7506d97af5481141671abf3ea"},
-    {file = "black-23.12.1-cp39-cp39-win_amd64.whl", hash = "sha256:dd15245c8b68fe2b6bd0f32c1556509d11bb33aec9b5d0866dd8e2ed3dba09c2"},
-    {file = "black-23.12.1-py3-none-any.whl", hash = "sha256:78baad24af0f033958cad29731e27363183e140962595def56423e626f4bee3e"},
-    {file = "black-23.12.1.tar.gz", hash = "sha256:4ce3ef14ebe8d9509188014d96af1c456a910d5b5cbf434a09fef7e024b3d0d5"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-packaging = ">=22.0"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4) ; sys_platform != \"win32\" or implementation_name != \"pypy\"", "aiohttp (>=3.7.4,!=3.9.0) ; sys_platform == \"win32\" and implementation_name == \"pypy\""]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
 name = "certifi"
 version = "2025.1.31"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -1626,18 +1579,6 @@ docs = ["docutils (==0.17.1)", "sphinx (==3.2.1)", "sphinx-autodoc-typehints (==
 testing = ["ipywidgets", "multiprocess (>=0.70.15) ; python_version >= \"3.11\"", "multiprocess ; python_version < \"3.11\"", "numpy", "pywin32 (>=301) ; platform_system == \"Windows\"", "rich"]
 
 [[package]]
-name = "mypy-extensions"
-version = "1.0.0"
-description = "Type system extensions for programs checked with the mypy type checker."
-optional = false
-python-versions = ">=3.5"
-groups = ["dev"]
-files = [
-    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
-    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
-]
-
-[[package]]
 name = "myst-parser"
 version = "4.0.1"
 description = "An extended [CommonMark](https://spec.commonmark.org/) compliant parser,"
@@ -1748,18 +1689,6 @@ groups = ["main", "dev"]
 files = [
     {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
     {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
-]
-
-[[package]]
-name = "pathspec"
-version = "0.12.1"
-description = "Utility library for gitignore style pattern matching of file paths."
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
-    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
 ]
 
 [[package]]
@@ -3598,4 +3527,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "d59226b48240158a1df55dab57dde09c94d604d5deb1023c775b4fedc8873e51"
+content-hash = "fb316fe12a214c01be7495931d308592fe895359ae66380c5f12b069c8bdfe77"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ sphinx-design = "^0.5"
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0"
 pytest-cov = "^4.0"
-black = "^23.1.0"
 pre-commit = "^3.1.1"
 ruff = "^0.5"
 jinja2 = "*"

--- a/src/spl_core/gcov_maid/gcov_maid.py
+++ b/src/spl_core/gcov_maid/gcov_maid.py
@@ -4,12 +4,8 @@ from pathlib import Path
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Script with command line options")
-    parser.add_argument(
-        "--working-dir", help="Working directory", required=True
-    )  # Make the option mandatory
-    parser.add_argument(
-        "--wipe-all-gcda", action="store_true", help="Wipe all gcda files recursively"
-    )
+    parser.add_argument("--working-dir", help="Working directory", required=True)  # Make the option mandatory
+    parser.add_argument("--wipe-all-gcda", action="store_true", help="Wipe all gcda files recursively")
     parser.add_argument(
         "--wipe-orphaned-gcno",
         action="store_true",

--- a/src/spl_core/kickstart/templates/project/.vscode/settings.json
+++ b/src/spl_core/kickstart/templates/project/.vscode/settings.json
@@ -40,6 +40,6 @@
     "git.repositoryScanMaxDepth": 3,
     "git-graph.maxDepthOfRepoSearch": 3,
     "[python]": {
-        "editor.defaultFormatter": "ms-python.black-formatter"
+        "editor.defaultFormatter": "charliermarsh.ruff"
     }
 }

--- a/tests/unit/test_spl_build.py
+++ b/tests/unit/test_spl_build.py
@@ -14,6 +14,7 @@ def spl_build(tmp_path_factory):
     os.chdir(tmp_path_factory.mktemp("spl_build"))
     return SplBuild(variant="my_var", build_kit="defaultKit")
 
+
 def test_build_dir(spl_build: SplBuild) -> None:
     """
     Test that the build directory is constructed correctly.
@@ -98,10 +99,8 @@ def test_create_artifacts_archive_inside_spl_build(spl_build: SplBuild) -> None:
         file_list = zip_ref.namelist()
         assert file_list == expected_artifacts
 
-    assert dict(json.loads(archive_json.read_text())) == {'variant': 'my_var',
-                                                          'build_kit': 'defaultKit',
-                                                          'artifacts': expected_artifacts
-                                                          }
+    assert dict(json.loads(archive_json.read_text())) == {"variant": "my_var", "build_kit": "defaultKit", "artifacts": expected_artifacts}
+
 
 def test_create_artifacts_archive_outside_spl_build(spl_build: SplBuild, tmp_path: Path) -> None:
     """
@@ -125,7 +124,4 @@ def test_create_artifacts_archive_outside_spl_build(spl_build: SplBuild, tmp_pat
         file_list = zip_ref.namelist()
         assert file_list == expected_artifacts
 
-    assert dict(json.loads(archive_json.read_text())) == {'variant': 'my_var',
-                                                          'build_kit': 'defaultKit',
-                                                          'artifacts': expected_artifacts
-                                                          }
+    assert dict(json.loads(archive_json.read_text())) == {"variant": "my_var", "build_kit": "defaultKit", "artifacts": expected_artifacts}


### PR DESCRIPTION
There is a security warning about `black < 24.3.0`: 
https://github.com/avengineers/spl-core/security/dependabot/9

SPL core was still using `back==23.1.0` as a dependency.
I first thought to upgrade it to `24.3.0` as proposed by dependabot. But after upgrading and reformatting I noticed that you mainly use `ruff` by now...which makes sense due to the speed and stuff.

So instead I removed the `black` dependency completely. I also changed the templating to use `ruff` instead of `black`. I guess this was a left over from a change.

Afterwards I also did a `ruff format .` on the entire code base, but only hit 2 files for formatting.