### PR TITLE
test(ci): upload coverage and test results to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,23 @@ jobs:
                   files: |
                       out/test-report.xml
 
+            - name: Upload coverage to Codecov
+              uses: codecov/codecov-action@v5
+              if: always()
+              with:
+                  files: out/coverage.xml
+                  fail_ci_if_error: true
+                  token: ${{ secrets.CODECOV_TOKEN }}
+
+            - name: Upload test results to Codecov
+              uses: codecov/codecov-action@v5
+              if: always()
+              with:
+                  files: out/test-report.xml
+                  report_type: test_results
+                  fail_ci_if_error: true
+                  token: ${{ secrets.CODECOV_TOKEN }}
+
     release:
         needs:
             - test

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,24 @@
+# Codecov configuration — https://docs.codecov.com/docs/codecovyml-reference
+# Quality gate: every line a PR adds or changes must be covered by tests.
+coverage:
+    status:
+        # Patch = coverage of the lines touched by this PR. This is the gate
+        # that rejects PRs which introduce untested code.
+        patch:
+            default:
+                target: 100% # every new/changed line must be covered
+                threshold: 0% # no tolerance
+                informational: false # hard failure, not just a warning
+        # Project = overall repository coverage. Enforced as a hard gate too:
+        # total coverage may not drop below the base commit (target: auto,
+        # zero tolerance).
+        project:
+            default:
+                target: auto
+                threshold: 0%
+                informational: false
+
+# Only lines that coverage.py actually measures are counted. Code reachable
+# solely through the integration tests (which run `please` as a subprocess and
+# are intentionally NOT measured) reads as uncovered here — cover such code with
+# unit tests, or mark genuinely unreachable lines with `# pragma: no cover`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ match = "(?!develop$)"
 prerelease = true
 
 [tool.pytest.ini_options]
-addopts = " -vv --capture=tee-sys --junitxml=out/test-report.xml"
+addopts = " -vv --capture=tee-sys --junitxml=out/test-report.xml --cov=spl_core --cov-report=xml:out/coverage.xml --cov-report=term-missing"
 pythonpath = ["src", "tests"]
 testpaths = ["tests"]
 junit_logging = "all"
@@ -99,6 +99,14 @@ markers = [
 
 [tool.coverage.run]
 branch = true
+source = ["spl_core"]
+relative_files = true
+
+# Map the installed package back to the source tree so Codecov shows coverage
+# against src/spl_core regardless of whether tests import the editable checkout
+# or the copy Poetry installs into the venv's site-packages.
+[tool.coverage.paths]
+source = ["src/spl_core", "*/site-packages/spl_core", "*\\site-packages\\spl_core"]
 
 [tool.coverage.report]
 exclude_lines = [


### PR DESCRIPTION
Generate coverage.xml during pytest (--cov=spl_core) and upload it plus the JUnit report to Codecov from the Windows test job, mirroring the sple-skills setup. Map src/spl_core to the venv site-packages copy so Codecov attributes coverage to the source tree regardless of install mode.

Integration tests run please as a subprocess and are intentionally not counted; only in-process (mainly unit) coverage is measured.