### PR TITLE
feat: add build properties to artifacts-archiver and extract tag_name…

### DIFF
--- a/src/spl_core/test_utils/artifacts_archiver.py
+++ b/src/spl_core/test_utils/artifacts_archiver.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -22,12 +23,14 @@ class BuildMetadata:
         build_number: The build number or "local_build"
         is_tag: Whether this is a tag build
         pr_number: The PR number (without "PR-" prefix) for pull request builds, None otherwise
+        baseline_label: A label identifying the build baseline (e.g. extracted from a git tag or release branch name), None otherwise
     """
 
     branch_name: str
     build_number: str
     is_tag: bool
     pr_number: str | None
+    baseline_label: str | None = None
 
 
 @dataclass
@@ -259,7 +262,8 @@ class ArtifactsArchiver:
         metadata = self._get_build_metadata()
 
         # Construct the URL following the same pattern as create_rt_upload_json
-        archive_url = f"{self.artifactory_base_url}/{target_repo}/{metadata.branch_name}/{metadata.build_number}/{archive.archive_name}"
+        deploy_branch = self._sanitize_branch_for_path(metadata.branch_name)
+        archive_url = f"{self.artifactory_base_url}/{target_repo}/{deploy_branch}/{metadata.build_number}/{archive.archive_name}"
 
         return archive_url
 
@@ -319,6 +323,7 @@ class ArtifactsArchiver:
         build_number = "local_build"
         is_tag = False
         pr_number = None
+        baseline_label_value: str | None = None
 
         if os.environ.get("JENKINS_URL"):
             change_id = os.environ.get("CHANGE_ID")
@@ -331,12 +336,24 @@ class ArtifactsArchiver:
                 branch_name = f"PR-{change_id}"
                 pr_number = change_id
             elif tag_name:
-                # Tag build case
-                branch_name = tag_name
                 is_tag = True
+                branch_name = tag_name
+                if "#" in tag_name and tag_name.startswith("release/"):
+                    # Release tag with embedded variant in variant#tag syntax (e.g. release/Disco#ci_test_v3).
+                    # Everything after the '#' is the tag name, slashes included.
+                    match = re.search(r"#(.+)$", tag_name)
+                    baseline_label_value = match.group(1).strip() if match else tag_name
+                else:
+                    # Pure git tag build: TAG_NAME set, BRANCH_NAME equals the tag
+                    baseline_label_value = tag_name
             elif jenkins_branch_name:
-                # Regular branch case
                 branch_name = jenkins_branch_name
+                if "#" in jenkins_branch_name and jenkins_branch_name.startswith("release/"):
+                    # Release branch with embedded tag in variant#tag syntax (e.g. release/Disco#ci_test_v3).
+                    # Everything after the '#' is the tag name, slashes included.
+                    match = re.search(r"#(.+)$", jenkins_branch_name)
+                    if match:
+                        baseline_label_value = match.group(1).strip()
 
             if jenkins_build_number:
                 build_number = jenkins_build_number
@@ -346,7 +363,24 @@ class ArtifactsArchiver:
             build_number=build_number,
             is_tag=is_tag,
             pr_number=pr_number,
+            baseline_label=baseline_label_value,
         )
+
+    @staticmethod
+    def _sanitize_branch_for_path(branch_name: str) -> str:
+        """
+        Rejoin a variant#tag or variant/#tag release ref (e.g. "release/Disco#ci_test_v3")
+        with a plain '/' so it never contains a literal '#' when used to build an
+        Artifactory upload path or URL. A literal '#' is unsafe there since it is
+        interpreted as a URL fragment separator.
+
+        The unmodified branch_name (with the '#') is still used for the "branch=" prop,
+        so the original ref stays visible in the artifact's metadata for traceability.
+        """
+        match = re.match(r"^(?P<variant>[^#]+?)/?#(?P<tag>.*)$", branch_name)
+        if match:
+            return f"{match.group('variant')}/{match.group('tag')}"
+        return branch_name
 
     @staticmethod
     def _get_git_metadata() -> GitMetadata:
@@ -389,15 +423,17 @@ class ArtifactsArchiver:
             except Exception as e:
                 logger.warning(f"Failed to get commit ID from git: {e}")
 
-        # Get commit message (subject line only)
-        if not commit_message:
-            try:
-                result = SubprocessExecutor(["git", "log", "-1", "--format=%s"]).execute(handle_errors=False)
-                if result and result.returncode == 0:
-                    value = result.stdout.strip()
-                    commit_message = value if value else None
-            except Exception as e:
-                logger.warning(f"Failed to get commit message from git: {e}")
+        # Get commit message (subject line only).
+        # No guard here: unlike commit_id/repository_url, commit_message is never pre-populated
+        # from an environment variable (neither Jenkins nor GitHub Actions expose it), so it is
+        # always None at this point and there is nothing to check before falling back to git.
+        try:
+            result = SubprocessExecutor(["git", "log", "-1", "--format=%s"]).execute(handle_errors=False)
+            if result and result.returncode == 0:
+                value = result.stdout.strip()
+                commit_message = value if value else None
+        except Exception as e:
+            logger.warning(f"Failed to get commit message from git: {e}")
 
         # Get repository URL
         if not repository_url:
@@ -415,6 +451,44 @@ class ArtifactsArchiver:
             repository_url=repository_url,
         )
 
+    @staticmethod
+    def _build_commit_link(repository_url: str | None, commit_id: str | None) -> str | None:
+        """
+        Build a web link to a specific commit from the git remote URL and commit SHA.
+
+        Supports Bitbucket Server (HTTPS and SSH), GitHub, and GitLab remote URL patterns.
+
+        Args:
+            repository_url: The git remote URL (e.g. from GIT_URL or git config remote.origin.url)
+            commit_id: The full git commit SHA
+
+        Returns:
+            A browsable web URL for the commit, or None if the URL pattern is not recognised
+        """
+        if not repository_url or not commit_id:
+            return None
+        # Bitbucket Server HTTPS: https://host/scm/org/repo[.git]
+        match = re.match(r"(https?://[^/]+)/scm/([^/]+)/([^/?#]+?)(?:\.git)?/?$", repository_url, re.IGNORECASE)
+        if match:
+            base_url, org, repo = match.groups()
+            return f"{base_url}/projects/{org.upper()}/repos/{repo}/commits/{commit_id}"
+        # Bitbucket Server SSH: ssh://git@host[:port]/org/repo[.git]
+        match = re.match(r"ssh://[^@]+@([^:/]+)(?::\d+)?/([^/]+)/([^/?#]+?)(?:\.git)?/?$", repository_url, re.IGNORECASE)
+        if match:
+            host, org, repo = match.groups()
+            return f"https://{host}/projects/{org.upper()}/repos/{repo}/commits/{commit_id}"
+        # GitLab HTTPS: https://gitlab.com/org/repo[.git]  (must be checked before GitHub generic pattern)
+        match = re.match(r"(https?://[^/]*gitlab[^/]*)/(.+?)(?:\.git)?/?$", repository_url, re.IGNORECASE)
+        if match:
+            base_url, path = match.groups()
+            return f"{base_url}/{path}/-/commit/{commit_id}"
+        # GitHub / generic HTTPS: https://host/org/repo[.git]
+        match = re.match(r"(https?://[^/]+)/(.+?)(?:\.git)?/?$", repository_url, re.IGNORECASE)
+        if match:
+            base_url, path = match.groups()
+            return f"{base_url}/{path}/commit/{commit_id}"
+        return None
+
     def create_rt_upload_json(self, out_dir: Path) -> Path:
         """
         Create a single rt-upload.json file containing all archives.
@@ -431,9 +505,31 @@ class ArtifactsArchiver:
         """
         # Get build metadata from environment or defaults
         metadata = self._get_build_metadata()
+        git_metadata = self._get_git_metadata()
+        deploy_branch = self._sanitize_branch_for_path(metadata.branch_name)
 
         # Calculate retention period based on branch/tag
         retention_period = self.calculate_retention_period(metadata.branch_name, metadata.is_tag)
+
+        # Build the props string with all available VCS metadata
+        props_parts = [f"retention_period={retention_period}"]
+        if git_metadata.commit_id:
+            props_parts.append(f"commit_id={git_metadata.commit_id}")
+        if metadata.is_tag:
+            # tag_name stays the full git tag ref for traceability; baseline_label is the derived label.
+            props_parts.append(f"tag_name={metadata.branch_name}")
+            if metadata.baseline_label and metadata.baseline_label != metadata.branch_name:
+                props_parts.append(f"baseline_label={metadata.baseline_label}")
+        elif metadata.pr_number:
+            props_parts.append(f"pull_request={metadata.pr_number}")
+        else:
+            props_parts.append(f"branch={metadata.branch_name}")
+            if metadata.baseline_label:
+                props_parts.append(f"baseline_label={metadata.baseline_label}")
+        commit_link = self._build_commit_link(git_metadata.repository_url, git_metadata.commit_id)
+        if commit_link:
+            props_parts.append(f"commit_link={commit_link}")
+        props = ";".join(props_parts)
 
         # Create the files array for Artifactory upload format
         files_array = []
@@ -443,9 +539,8 @@ class ArtifactsArchiver:
                 target_repo = self._target_repos[archive_name]
 
                 # Construct the RT target path
-                rt_target = f"{target_repo}/{metadata.branch_name}/{metadata.build_number}/"
+                rt_target = f"{target_repo}/{deploy_branch}/{metadata.build_number}/"
 
-                # Add this archive to the files array with retention_period property
                 files_array.append(
                     {
                         "pattern": archive.archive_name,
@@ -453,7 +548,7 @@ class ArtifactsArchiver:
                         "recursive": "false",
                         "flat": "false",
                         "regexp": "false",
-                        "props": f"retention_period={retention_period}",
+                        "props": props,
                     }
                 )
 
@@ -477,8 +572,10 @@ class ArtifactsArchiver:
 
         The JSON file includes conditional keys based on the build type:
         - For pull requests: includes "pull_request" key with the PR number (e.g., "117")
-        - For tag builds: includes "tag" key with the tag name (e.g., "v1.2.3")
-        - For regular branch builds: includes "branch" key with the branch name (e.g., "develop")
+        - For tag builds: includes "tag" key with the full git tag ref (e.g., "v1.2.3"), plus a
+          "baseline_label" key with the derived label when it differs from the tag ref
+        - For regular branch builds: includes "branch" key with the branch name (e.g., "develop"),
+          plus a "baseline_label" key when a baseline label was derived from the branch name
 
         Optional fields (included only if available):
         - build_url: Jenkins build URL from BUILD_URL environment variable
@@ -521,11 +618,15 @@ class ArtifactsArchiver:
             # Pull request build
             artifacts_data["pull_request"] = build_metadata.pr_number
         elif build_metadata.is_tag:
-            # Tag build
+            # Tag build: "tag" stays the full git tag ref; add the derived baseline_label if it differs.
             artifacts_data["tag"] = build_metadata.branch_name
+            if build_metadata.baseline_label and build_metadata.baseline_label != build_metadata.branch_name:
+                artifacts_data["baseline_label"] = build_metadata.baseline_label
         else:
-            # Regular branch build (or local build)
+            # Branch build (regular or with embedded baseline label)
             artifacts_data["branch"] = build_metadata.branch_name
+            if build_metadata.baseline_label:
+                artifacts_data["baseline_label"] = build_metadata.baseline_label
 
         # Add git metadata if available
         if git_metadata.commit_id:

--- a/tests/unit/test_archive_artifacts_collection.py
+++ b/tests/unit/test_archive_artifacts_collection.py
@@ -439,6 +439,29 @@ class TestArchiveArtifactsCollection:
         json_content = json.loads(json_path.read_text())
         assert json_content["artifacts"] == []
 
+    def test_init_with_directory_outside_build_dir(self, tmp_path):
+        """Test directory artifact outside build_dir: files are flattened to their name."""
+        # Arrange
+        build_dir = tmp_path / "build"
+        build_dir.mkdir()
+
+        # External directory (not inside build_dir)
+        external_dir = tmp_path / "external"
+        external_dir.mkdir()
+        file1 = external_dir / "ext_file1.txt"
+        file1.write_text("external content 1")
+        file2 = external_dir / "ext_file2.txt"
+        file2.write_text("external content 2")
+
+        # Act
+        collection = ArchiveArtifactsCollection([external_dir], build_dir)
+
+        # Assert - files outside build_dir in a directory are stored by filename only
+        assert len(collection.archive_artifacts) == 2
+        archive_paths = {artifact.archive_path for artifact in collection.archive_artifacts}
+        assert Path("ext_file1.txt") in archive_paths
+        assert Path("ext_file2.txt") in archive_paths
+
     def test_mixed_files_and_directories(self, tmp_path):
         """Test initialization with a mix of files and directories."""
         # Arrange

--- a/tests/unit/test_artifacts_archiver.py
+++ b/tests/unit/test_artifacts_archiver.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from spl_core.test_utils.artifacts_archiver import ArtifactsArchiver
+from spl_core.test_utils.artifacts_archiver import ArtifactsArchive, ArtifactsArchiver
 
 # Artifactory base URL constant for tests
 ARTIFACTORY_BASE_URL = "https://artifactory.example.com/artifactory"
@@ -240,7 +240,6 @@ def test_create_archive_with_relative_out_dir_writes_to_correct_location(test_di
     assert archive_path.stat().st_size > 0, "Archive file should not be empty"
 
 
-
 @pytest.mark.parametrize(
     "jenkins_url,change_id,branch_name,tag_name,build_number,expected_branch,expected_build,expected_retention",
     [
@@ -302,12 +301,14 @@ def test_multiple_archives_with_target_repos(test_dir, test_files, monkeypatch, 
         },
     ]
 
-    # Act
-    for config in archives_config:
-        archiver.add_archive(output_dir, config["filename"], archive_name=config["name"], target_repo=config["target_repo"])
-        archiver.register(config["files"], archive_name=config["name"])
-    archive_paths_dict = archiver.create_all_archives()
-    rt_upload_path = archiver.create_rt_upload_json(output_dir)
+    # Isolate from real git metadata so props only contain build/retention info
+    with patch.object(ArtifactsArchiver, "_get_git_metadata", return_value=MagicMock(commit_id=None, repository_url=None)):
+        # Act
+        for config in archives_config:
+            archiver.add_archive(output_dir, config["filename"], archive_name=config["name"], target_repo=config["target_repo"])
+            archiver.register(config["files"], archive_name=config["name"])
+        archive_paths_dict = archiver.create_all_archives()
+        rt_upload_path = archiver.create_rt_upload_json(output_dir)
 
     # Assert
     assert len(archive_paths_dict) == 3, "Should have created 3 archives"
@@ -332,6 +333,16 @@ def test_multiple_archives_with_target_repos(test_dir, test_files, monkeypatch, 
     # Should have exactly 2 entries (only archives with target repos)
     assert len(files_list) == 2, "rt-upload.json should contain exactly 2 files"
 
+    # Build expected props: retention + branch context (no git metadata in this test)
+    is_tag = tag_name is not None and jenkins_url is not None
+    is_pr = change_id is not None and jenkins_url is not None
+    if is_tag:
+        expected_props = f"retention_period={expected_retention};tag_name={expected_branch}"
+    elif is_pr:
+        expected_props = f"retention_period={expected_retention};pull_request={change_id}"
+    else:
+        expected_props = f"retention_period={expected_retention};branch={expected_branch}"
+
     # Expected JSON structure with the expected target paths from test parameters
     expected_json = {
         "files": [
@@ -341,7 +352,7 @@ def test_multiple_archives_with_target_repos(test_dir, test_files, monkeypatch, 
                 "recursive": "false",
                 "flat": "false",
                 "regexp": "false",
-                "props": f"retention_period={expected_retention}",
+                "props": expected_props,
             },
             {
                 "pattern": "configuration.7z",
@@ -349,7 +360,7 @@ def test_multiple_archives_with_target_repos(test_dir, test_files, monkeypatch, 
                 "recursive": "false",
                 "flat": "false",
                 "regexp": "false",
-                "props": f"retention_period={expected_retention}",
+                "props": expected_props,
             },
         ]
     }
@@ -380,6 +391,277 @@ def testcalculate_retention_period(branch_name, is_tag, expected_retention):
 
     # Assert
     assert retention_period == expected_retention, f"Retention period for {branch_name} (is_tag={is_tag}) should be {expected_retention}, got {retention_period}"
+
+
+# =============================================================================
+# Tests for _build_commit_link
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "repository_url,commit_id,expected_link",
+    [
+        # Bitbucket Server HTTPS
+        (
+            "https://git.example.de/scm/sple/my_project.git",
+            "abc123def456",
+            "https://git.example.de/projects/SPLE/repos/my_project/commits/abc123def456",
+        ),
+        # Bitbucket Server HTTPS without .git suffix
+        (
+            "https://git.example.de/scm/myorg/myrepo",
+            "abc123",
+            "https://git.example.de/projects/MYORG/repos/myrepo/commits/abc123",
+        ),
+        # Bitbucket Server SSH
+        (
+            "ssh://git@git.example.de:7999/sple/my_project.git",
+            "abc123def456",
+            "https://git.example.de/projects/SPLE/repos/my_project/commits/abc123def456",
+        ),
+        # GitHub HTTPS
+        (
+            "https://github.com/myorg/myrepo.git",
+            "abc123",
+            "https://github.com/myorg/myrepo/commit/abc123",
+        ),
+        # GitHub HTTPS without .git suffix
+        (
+            "https://github.com/myorg/myrepo",
+            "abc123",
+            "https://github.com/myorg/myrepo/commit/abc123",
+        ),
+        # GitLab HTTPS
+        (
+            "https://gitlab.com/myorg/myrepo.git",
+            "abc123",
+            "https://gitlab.com/myorg/myrepo/-/commit/abc123",
+        ),
+        # Self-hosted GitLab
+        (
+            "https://gitlab.example.com/myorg/myrepo.git",
+            "abc123",
+            "https://gitlab.example.com/myorg/myrepo/-/commit/abc123",
+        ),
+        # None inputs
+        (None, "abc123", None),
+        ("https://github.com/org/repo.git", None, None),
+        (None, None, None),
+    ],
+)
+def test_build_commit_link(repository_url, commit_id, expected_link):
+    """Test commit link construction for various git hosting platforms."""
+    result = ArtifactsArchiver._build_commit_link(repository_url, commit_id)
+    assert result == expected_link
+
+
+def test_create_rt_upload_json_includes_vcs_props(test_dir, test_files, monkeypatch):
+    """Test that rt-upload.json props include commit_id, branch, and commit_link when git metadata is available."""
+    # Arrange
+    for env_var in ["JENKINS_URL", "CHANGE_ID", "BRANCH_NAME", "TAG_NAME", "BUILD_NUMBER", "GIT_COMMIT", "GIT_URL"]:
+        monkeypatch.delenv(env_var, raising=False)
+
+    monkeypatch.setenv("JENKINS_URL", "http://jenkins.example.com")
+    monkeypatch.setenv("BRANCH_NAME", "develop")
+    monkeypatch.setenv("BUILD_NUMBER", "42")
+    monkeypatch.setenv("GIT_COMMIT", "9e13adc68c86ef962e15563bcdc8791439b61551")
+    monkeypatch.setenv("GIT_URL", "https://git.example.de/scm/sple/spled.git")
+
+    archiver = ArtifactsArchiver()
+    output_dir = test_dir / "output"
+    archiver.add_archive(output_dir, "result.7z", target_repo="my-repo/results")
+    archiver.register(test_files[:2])
+    archiver.create_archive()
+
+    # Act
+    rt_upload_path = archiver.create_rt_upload_json(output_dir)
+
+    # Assert
+    with open(rt_upload_path) as f:
+        data = json.load(f)
+
+    props = data["files"][0]["props"]
+    assert "retention_period=84" in props
+    assert "commit_id=9e13adc68c86ef962e15563bcdc8791439b61551" in props
+    assert "branch=develop" in props
+    assert "commit_link=https://git.example.de/projects/SPLE/repos/spled/commits/9e13adc68c86ef962e15563bcdc8791439b61551" in props
+
+
+def test_create_rt_upload_json_tag_build_props(test_dir, test_files, monkeypatch):
+    """Test that rt-upload.json props include tag_name instead of branch for tag builds."""
+    for env_var in ["JENKINS_URL", "CHANGE_ID", "BRANCH_NAME", "TAG_NAME", "BUILD_NUMBER", "GIT_COMMIT", "GIT_URL"]:
+        monkeypatch.delenv(env_var, raising=False)
+
+    monkeypatch.setenv("JENKINS_URL", "http://jenkins.example.com")
+    monkeypatch.setenv("BRANCH_NAME", "v1.2.3")
+    monkeypatch.setenv("TAG_NAME", "v1.2.3")
+    monkeypatch.setenv("BUILD_NUMBER", "99")
+    monkeypatch.setenv("GIT_COMMIT", "deadbeef")
+    monkeypatch.setenv("GIT_URL", "https://github.com/myorg/myrepo.git")
+
+    archiver = ArtifactsArchiver()
+    output_dir = test_dir / "output"
+    archiver.add_archive(output_dir, "release.7z", target_repo="my-repo/releases")
+    archiver.register(test_files[:1])
+    archiver.create_archive()
+
+    rt_upload_path = archiver.create_rt_upload_json(output_dir)
+
+    with open(rt_upload_path) as f:
+        data = json.load(f)
+
+    props = data["files"][0]["props"]
+    assert "tag_name=v1.2.3" in props
+    assert "branch=" not in props
+    assert "commit_id=deadbeef" in props
+    assert "commit_link=https://github.com/myorg/myrepo/commit/deadbeef" in props
+
+
+def test_create_rt_upload_json_branch_with_embedded_tag(test_dir, test_files, monkeypatch):
+    """Test that for a branch with variant#tag syntax, the deploy path has the '#'
+    replaced with '/', while props still carry the original branch and extracted tag,
+    without TAG_NAME needing to be set."""
+    for env_var in ["JENKINS_URL", "CHANGE_ID", "BRANCH_NAME", "TAG_NAME", "BUILD_NUMBER", "GIT_COMMIT", "GIT_URL"]:
+        monkeypatch.delenv(env_var, raising=False)
+
+    monkeypatch.setenv("JENKINS_URL", "http://jenkins.example.com")
+    monkeypatch.setenv("BRANCH_NAME", "release/Disco#ci_test_v3")
+    monkeypatch.setenv("BUILD_NUMBER", "42")
+
+    archiver = ArtifactsArchiver()
+    output_dir = test_dir / "output"
+    archiver.add_archive(output_dir, "result.7z", target_repo="my-repo/results")
+    archiver.register(test_files[:1])
+    archiver.create_archive()
+
+    with patch.object(ArtifactsArchiver, "_get_git_metadata", return_value=MagicMock(commit_id=None, repository_url=None)):
+        rt_upload_path = archiver.create_rt_upload_json(output_dir)
+
+    with open(rt_upload_path) as f:
+        data = json.load(f)
+
+    file_entry = data["files"][0]
+    # The deploy path has the '#' replaced with '/' so it's safe to use in Artifactory/URLs
+    assert file_entry["target"] == "my-repo/results/release/Disco/ci_test_v3/42/"
+    # Props carry the original branch name (with the literal #tag) and the extracted baseline label
+    assert "branch=release/Disco#ci_test_v3" in file_entry["props"]
+    assert "baseline_label=ci_test_v3" in file_entry["props"]
+
+
+def test_create_rt_upload_json_branch_with_embedded_tag_no_double_slash(test_dir, test_files, monkeypatch):
+    """Test that a branch name with /# does not produce a double slash once sanitized."""
+    for env_var in ["JENKINS_URL", "CHANGE_ID", "BRANCH_NAME", "TAG_NAME", "BUILD_NUMBER", "GIT_COMMIT", "GIT_URL", "SPL_DEPLOY_BRANCH"]:
+        monkeypatch.delenv(env_var, raising=False)
+
+    monkeypatch.setenv("JENKINS_URL", "http://jenkins.example.com")
+    # User wrote /# explicitly in the branch name
+    monkeypatch.setenv("BRANCH_NAME", "release/Disco/#ci_test_v3")
+    monkeypatch.setenv("BUILD_NUMBER", "7")
+
+    archiver = ArtifactsArchiver()
+    output_dir = test_dir / "output"
+    archiver.add_archive(output_dir, "result.7z", target_repo="my-repo/results")
+    archiver.register(test_files[:1])
+    archiver.create_archive()
+
+    with patch.object(ArtifactsArchiver, "_get_git_metadata", return_value=MagicMock(commit_id=None, repository_url=None)):
+        rt_upload_path = archiver.create_rt_upload_json(output_dir)
+
+    with open(rt_upload_path) as f:
+        data = json.load(f)
+
+    file_entry = data["files"][0]
+    # Sanitized deploy path — no double slashes introduced
+    assert "//" not in file_entry["target"]
+    assert file_entry["target"] == "my-repo/results/release/Disco/ci_test_v3/7/"
+    # Props carry the original branch name (with the literal /#tag) and the extracted baseline label
+    assert "branch=release/Disco/#ci_test_v3" in file_entry["props"]
+    assert "baseline_label=ci_test_v3" in file_entry["props"]
+
+
+def test_create_rt_upload_json_branch_with_embedded_tag_containing_slashes(test_dir, test_files, monkeypatch):
+    """Test that everything after '#' is taken as the tag name, including slashes.
+
+    Slashes are explicitly allowed after the '#' and must not be truncated."""
+    for env_var in ["JENKINS_URL", "CHANGE_ID", "BRANCH_NAME", "TAG_NAME", "BUILD_NUMBER", "GIT_COMMIT", "GIT_URL"]:
+        monkeypatch.delenv(env_var, raising=False)
+
+    monkeypatch.setenv("JENKINS_URL", "http://jenkins.example.com")
+    monkeypatch.setenv("BRANCH_NAME", "release/Disco/#tag_name/with/slashes")
+    monkeypatch.setenv("BUILD_NUMBER", "42")
+
+    archiver = ArtifactsArchiver()
+    output_dir = test_dir / "output"
+    archiver.add_archive(output_dir, "result.7z", target_repo="my-repo/results")
+    archiver.register(test_files[:1])
+    archiver.create_archive()
+
+    with patch.object(ArtifactsArchiver, "_get_git_metadata", return_value=MagicMock(commit_id=None, repository_url=None)):
+        rt_upload_path = archiver.create_rt_upload_json(output_dir)
+
+    with open(rt_upload_path) as f:
+        data = json.load(f)
+
+    file_entry = data["files"][0]
+    # The full tag name, including slashes, must be preserved (not truncated at the first slash)
+    assert "baseline_label=tag_name/with/slashes" in file_entry["props"]
+
+
+def test_create_rt_upload_json_release_branch_with_trailing_hash_has_no_baseline_label(test_dir, test_files, monkeypatch):
+    """A release branch ending in '#' (no tag after it) yields no baseline_label."""
+    for env_var in ["JENKINS_URL", "CHANGE_ID", "BRANCH_NAME", "TAG_NAME", "BUILD_NUMBER", "GIT_COMMIT", "GIT_URL"]:
+        monkeypatch.delenv(env_var, raising=False)
+
+    monkeypatch.setenv("JENKINS_URL", "http://jenkins.example.com")
+    monkeypatch.setenv("BRANCH_NAME", "release/Disco#")
+    monkeypatch.setenv("BUILD_NUMBER", "42")
+
+    archiver = ArtifactsArchiver()
+    output_dir = test_dir / "output"
+    archiver.add_archive(output_dir, "result.7z", target_repo="my-repo/results")
+    archiver.register(test_files[:1])
+    archiver.create_archive()
+
+    with patch.object(ArtifactsArchiver, "_get_git_metadata", return_value=MagicMock(commit_id=None, repository_url=None)):
+        rt_upload_path = archiver.create_rt_upload_json(output_dir)
+
+    with open(rt_upload_path) as f:
+        data = json.load(f)
+
+    file_entry = data["files"][0]
+    # No tag after '#', so no baseline_label is emitted; the original branch is still carried
+    assert "branch=release/Disco#" in file_entry["props"]
+    assert "baseline_label=" not in file_entry["props"]
+
+
+def test_create_rt_upload_json_release_tag_with_embedded_label(test_dir, test_files, monkeypatch):
+    """Test that for a release tag with variant#label syntax, props carry the full tag ref
+    via tag_name and the derived label via baseline_label."""
+    for env_var in ["JENKINS_URL", "CHANGE_ID", "BRANCH_NAME", "TAG_NAME", "BUILD_NUMBER", "GIT_COMMIT", "GIT_URL"]:
+        monkeypatch.delenv(env_var, raising=False)
+
+    monkeypatch.setenv("JENKINS_URL", "http://jenkins.example.com")
+    monkeypatch.setenv("BRANCH_NAME", "release/Disco#ci_test_v3")
+    monkeypatch.setenv("TAG_NAME", "release/Disco#ci_test_v3")
+    monkeypatch.setenv("BUILD_NUMBER", "42")
+
+    archiver = ArtifactsArchiver()
+    output_dir = test_dir / "output"
+    archiver.add_archive(output_dir, "result.7z", target_repo="my-repo/results")
+    archiver.register(test_files[:1])
+    archiver.create_archive()
+
+    with patch.object(ArtifactsArchiver, "_get_git_metadata", return_value=MagicMock(commit_id=None, repository_url=None)):
+        rt_upload_path = archiver.create_rt_upload_json(output_dir)
+
+    with open(rt_upload_path) as f:
+        data = json.load(f)
+
+    file_entry = data["files"][0]
+    # tag_name carries the full git tag ref, baseline_label the derived label
+    assert "tag_name=release/Disco#ci_test_v3" in file_entry["props"]
+    assert "baseline_label=ci_test_v3" in file_entry["props"]
+    assert "branch=" not in file_entry["props"]
 
 
 # =============================================================================
@@ -552,6 +834,27 @@ def test_get_archive_url_special_characters_in_branch(test_dir, monkeypatch):
     assert url == expected_url, f"Expected {expected_url}, got {url}"
 
 
+def test_get_archive_url_branch_with_embedded_tag(test_dir, monkeypatch):
+    """Test that get_archive_url replaces the '#' from a variant#tag branch with '/'."""
+    # Arrange
+    for env_var in ["JENKINS_URL", "CHANGE_ID", "BRANCH_NAME", "TAG_NAME", "BUILD_NUMBER"]:
+        monkeypatch.delenv(env_var, raising=False)
+
+    monkeypatch.setenv("JENKINS_URL", "http://jenkins.example.com")
+    monkeypatch.setenv("BRANCH_NAME", "release/Disco#ci_test_v3")
+    monkeypatch.setenv("BUILD_NUMBER", "42")
+
+    archiver = ArtifactsArchiver(artifactory_base_url=ARTIFACTORY_BASE_URL)
+    archiver.add_archive(test_dir, "result.7z", target_repo="my-repo/results")
+
+    # Act
+    url = archiver.get_archive_url()
+
+    # Assert
+    expected_url = f"{ARTIFACTORY_BASE_URL}/my-repo/results/release/Disco/ci_test_v3/42/result.7z"
+    assert url == expected_url, f"Expected {expected_url}, got {url}"
+
+
 def test_get_archive_url_without_artifactory_base_url(test_dir, monkeypatch):
     """Test get_archive_url returns None when archiver is initialized without artifactory_base_url."""
     # Arrange
@@ -570,6 +873,173 @@ def test_get_archive_url_without_artifactory_base_url(test_dir, monkeypatch):
 
     # Assert
     assert url is None, "Should return None when artifactory_base_url is not configured"
+
+
+def test_get_archive_url_returns_none_for_unknown_archive(test_dir):
+    """Test get_archive_url returns None when archive name does not exist."""
+    archiver = ArtifactsArchiver(artifactory_base_url=ARTIFACTORY_BASE_URL)
+    url = archiver.get_archive_url("nonexistent")
+    assert url is None
+
+
+def test_get_archive_url_returns_none_without_target_repo(test_dir, monkeypatch):
+    """Test get_archive_url returns None when archive has no target_repo configured."""
+    for env_var in ["JENKINS_URL", "CHANGE_ID", "BRANCH_NAME", "TAG_NAME", "BUILD_NUMBER"]:
+        monkeypatch.delenv(env_var, raising=False)
+
+    archiver = ArtifactsArchiver(artifactory_base_url=ARTIFACTORY_BASE_URL)
+    archiver.add_archive(test_dir, "result.7z")  # No target_repo
+
+    url = archiver.get_archive_url()
+    assert url is None
+
+
+def test_register_raises_key_error_for_unknown_archive():
+    """Test register raises KeyError when archive name does not exist."""
+    archiver = ArtifactsArchiver()
+    with pytest.raises(KeyError, match="nonexistent"):
+        archiver.register([Path("some_file.txt")], archive_name="nonexistent")
+
+
+def test_get_archive_raises_key_error_for_unknown_archive():
+    """Test get_archive raises KeyError when archive name does not exist."""
+    archiver = ArtifactsArchiver()
+    with pytest.raises(KeyError, match="nonexistent"):
+        archiver.get_archive("nonexistent")
+
+
+def test_create_archive_deletes_existing_archive(test_dir):
+    """Test that create_archive deletes the archive if it already exists before recreating it."""
+    archiver = ArtifactsArchiver()
+    output_dir = test_dir / "output"
+    output_dir.mkdir()
+    archive_path = output_dir / "test.7z"
+
+    # Pre-create a dummy file at the archive path
+    archive_path.write_text("old content")
+    assert archive_path.exists()
+
+    archiver.add_archive(output_dir, "test.7z")
+    # Create archive with no artifacts (placeholder will be created)
+    result_path = archiver.create_archive()
+
+    assert result_path.exists()
+    # The file should have been replaced, not be the old dummy file
+    assert result_path.stat().st_size > 0
+
+
+def test_create_archive_skips_nonexistent_artifact(test_dir):
+    """Test that create_archive skips artifacts that do not exist on disk."""
+    archiver = ArtifactsArchiver()
+    output_dir = test_dir / "output"
+    output_dir.mkdir()
+
+    # Register an artifact that does not exist
+    nonexistent = output_dir / "does_not_exist.txt"
+    archiver.add_archive(output_dir, "test.7z")
+    archiver.register([nonexistent])
+
+    # Should not raise; the missing artifact is skipped → placeholder is written
+    archive_path = archiver.create_archive()
+    assert archive_path.exists()
+
+
+def test_create_archive_with_directory_artifact(test_dir):
+    """Test that a directory artifact is staged correctly (copytree path)."""
+    output_dir = test_dir / "output"
+    output_dir.mkdir()
+
+    artifact_dir = output_dir / "reports"
+    artifact_dir.mkdir()
+    (artifact_dir / "file.html").write_text("<html/>")
+
+    archiver = ArtifactsArchiver()
+    archiver.add_archive(output_dir, "test.7z")
+    archiver.register([artifact_dir])
+
+    archive_path = archiver.create_archive()
+    assert archive_path.exists()
+    stored = _list_archive_paths(archive_path)
+    assert "reports/file.html" in stored
+
+
+def test_create_archive_raises_on_7z_failure(test_dir, test_files):
+    """Test that create_archive raises RuntimeError when 7z returns a non-zero exit code."""
+    archiver = ArtifactsArchiver()
+    output_dir = test_dir / "output"
+    archiver.add_archive(output_dir, "test.7z")
+    archiver.register(test_files[:1])
+
+    with patch("spl_core.test_utils.artifacts_archiver.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=1, stderr="7z error occurred", stdout="")
+        with pytest.raises(RuntimeError, match="7z failed"):
+            archiver.create_archive()
+
+
+def test_build_commit_link_returns_none_for_unrecognized_url():
+    """Test that _build_commit_link returns None for an SSH URL that doesn't match any known pattern."""
+    # Plain SCP-style git SSH (git@host:org/repo.git) is not matched by any pattern
+    result = ArtifactsArchiver._build_commit_link("git@github.com:myorg/myrepo.git", "abc123")
+    assert result is None
+
+
+def test_get_git_metadata_ignores_blank_env_vars(monkeypatch):
+    """Test that blank GIT_COMMIT and GIT_URL env vars are treated as None."""
+    for env_var in ["GIT_COMMIT", "GIT_URL"]:
+        monkeypatch.delenv(env_var, raising=False)
+
+    monkeypatch.setenv("GIT_COMMIT", "   ")  # whitespace only
+    monkeypatch.setenv("GIT_URL", "   ")  # whitespace only
+
+    # Patch git fallback commands to return None so we test only the env var handling
+    with patch("spl_core.test_utils.artifacts_archiver.SubprocessExecutor") as mock_exec_cls:
+        mock_instance = MagicMock()
+        mock_instance.execute.return_value = MagicMock(returncode=1, stdout="")
+        mock_exec_cls.return_value = mock_instance
+
+        from spl_core.test_utils.artifacts_archiver import ArtifactsArchiver as AA
+
+        metadata = AA._get_git_metadata()
+
+    assert metadata.commit_id is None
+    assert metadata.repository_url is None
+
+
+def test_get_git_metadata_handles_git_command_exceptions(monkeypatch):
+    """Test that _get_git_metadata handles exceptions from git commands gracefully."""
+    for env_var in ["GIT_COMMIT", "GIT_URL"]:
+        monkeypatch.delenv(env_var, raising=False)
+
+    with patch("spl_core.test_utils.artifacts_archiver.SubprocessExecutor") as mock_exec_cls:
+        mock_instance = MagicMock()
+        mock_instance.execute.side_effect = Exception("git not found")
+        mock_exec_cls.return_value = mock_instance
+
+        from spl_core.test_utils.artifacts_archiver import ArtifactsArchiver as AA
+
+        metadata = AA._get_git_metadata()
+
+    assert metadata.commit_id is None
+    assert metadata.commit_message is None
+    assert metadata.repository_url is None
+
+
+def test_create_artifacts_json_with_build_url(test_dir, monkeypatch):
+    """Test that create_artifacts_json includes build_url when BUILD_URL env var is set."""
+    for env_var in ["JENKINS_URL", "CHANGE_ID", "BRANCH_NAME", "TAG_NAME", "BUILD_NUMBER", "BUILD_URL", "GIT_COMMIT", "GIT_URL"]:
+        monkeypatch.delenv(env_var, raising=False)
+
+    monkeypatch.setenv("BUILD_URL", "http://jenkins.example.com/job/my-job/42/")
+
+    with patch.object(ArtifactsArchiver, "_get_git_metadata", return_value=MagicMock(commit_id=None, commit_message=None, repository_url=None)):
+        archiver = ArtifactsArchiver()
+        json_path = archiver.create_artifacts_json("MyVariant", test_dir)
+
+    with open(json_path) as f:
+        data = json.load(f)
+
+    assert "build_url" in data
+    assert data["build_url"] == "http://jenkins.example.com/job/my-job/42/"
 
 
 def test_get_archive_url_custom_artifactory_base_url(test_dir, monkeypatch):
@@ -685,6 +1155,49 @@ def test_create_artifacts_json_environment_detection(test_dir, monkeypatch, jenk
         assert data["branch"] == expected_branch, f"Branch should be {expected_branch}"
         assert "pull_request" not in data, "JSON should not contain 'pull_request' key for branch builds"
         assert "tag" not in data, "JSON should not contain 'tag' key for branch builds"
+
+
+def test_create_artifacts_json_release_tag_with_embedded_label(test_dir, monkeypatch):
+    """For a release tag with variant#label syntax, 'tag' carries the full git tag ref
+    and 'baseline_label' carries the derived label."""
+    for env_var in ["JENKINS_URL", "CHANGE_ID", "BRANCH_NAME", "TAG_NAME", "BUILD_NUMBER"]:
+        monkeypatch.delenv(env_var, raising=False)
+
+    monkeypatch.setenv("JENKINS_URL", "http://jenkins.example.com")
+    monkeypatch.setenv("BRANCH_NAME", "release/Disco#ci_test_v3")
+    monkeypatch.setenv("TAG_NAME", "release/Disco#ci_test_v3")
+    monkeypatch.setenv("BUILD_NUMBER", "42")
+
+    archiver = ArtifactsArchiver()
+    artifacts_json_path = archiver.create_artifacts_json("TestVariant", test_dir)
+
+    with open(artifacts_json_path) as f:
+        data = json.load(f)
+
+    assert data["tag"] == "release/Disco#ci_test_v3", "tag should be the full git tag ref"
+    assert data["baseline_label"] == "ci_test_v3", "baseline_label should be the derived label"
+    assert "branch" not in data
+
+
+def test_create_artifacts_json_branch_with_embedded_label(test_dir, monkeypatch):
+    """For a branch with variant#label syntax, 'branch' carries the full branch name
+    and 'baseline_label' carries the derived label."""
+    for env_var in ["JENKINS_URL", "CHANGE_ID", "BRANCH_NAME", "TAG_NAME", "BUILD_NUMBER"]:
+        monkeypatch.delenv(env_var, raising=False)
+
+    monkeypatch.setenv("JENKINS_URL", "http://jenkins.example.com")
+    monkeypatch.setenv("BRANCH_NAME", "release/Disco#ci_test_v3")
+    monkeypatch.setenv("BUILD_NUMBER", "42")
+
+    archiver = ArtifactsArchiver()
+    artifacts_json_path = archiver.create_artifacts_json("TestVariant", test_dir)
+
+    with open(artifacts_json_path) as f:
+        data = json.load(f)
+
+    assert data["branch"] == "release/Disco#ci_test_v3", "branch should be the full branch name"
+    assert data["baseline_label"] == "ci_test_v3", "baseline_label should be the derived label"
+    assert "tag" not in data
 
 
 def test_create_artifacts_json_structure(test_dir, monkeypatch):
@@ -1237,3 +1750,96 @@ def test_create_artifacts_json_with_git_from_commands(mock_subprocess, test_dir,
     # Verify local defaults
     assert data["branch"] == "local_branch"
     assert data["build_number"] == "local_build"
+
+
+def test_create_archive_skips_artifact_that_is_neither_file_nor_dir(test_dir):
+    """An artifact that exists but is neither a file nor a directory is silently skipped."""
+    archive = ArtifactsArchive(out_dir=test_dir / "out", archive_name="weird.7z")
+    fake_artifact = MagicMock()
+    fake_artifact.absolute_path.exists.return_value = True
+    fake_artifact.absolute_path.is_file.return_value = False
+    fake_artifact.absolute_path.is_dir.return_value = False
+    fake_artifact.archive_path = Path("weird_artifact")
+    archive.archive_artifacts = [fake_artifact]
+
+    result = archive.create_archive()
+
+    assert result.exists()
+
+
+def test_create_archive_logs_and_continues_when_staging_fails(test_dir, test_files):
+    """If copying an artifact into the staging dir fails, it is logged and skipped."""
+    archive = ArtifactsArchive(out_dir=test_dir / "out", archive_name="fail.7z")
+    archive.register([test_files[0]])
+
+    with patch("spl_core.test_utils.artifacts_archiver.shutil.copy2", side_effect=OSError("boom")):
+        result = archive.create_archive()
+
+    assert result.exists()
+
+
+def test_get_archive_raises_keyerror_for_unknown_name():
+    """get_archive raises KeyError when the requested archive does not exist."""
+    archiver = ArtifactsArchiver()
+    with pytest.raises(KeyError):
+        archiver.get_archive("does_not_exist")
+
+
+def test_get_archive_returns_registered_archive(test_dir):
+    """get_archive returns the ArtifactsArchive instance for a known name."""
+    archiver = ArtifactsArchiver()
+    added = archiver.add_archive(test_dir / "out", "a.7z")
+
+    assert archiver.get_archive("default") is added
+
+
+def test_get_build_metadata_jenkins_without_branch_or_build_number(monkeypatch):
+    """On Jenkins without CHANGE_ID/TAG_NAME/BRANCH_NAME/BUILD_NUMBER, local defaults are kept."""
+    for env_var in ["JENKINS_URL", "CHANGE_ID", "BRANCH_NAME", "TAG_NAME", "BUILD_NUMBER"]:
+        monkeypatch.delenv(env_var, raising=False)
+    monkeypatch.setenv("JENKINS_URL", "http://jenkins.example.com")
+
+    metadata = ArtifactsArchiver._get_build_metadata()
+
+    assert metadata.branch_name == "local_branch"
+    assert metadata.build_number == "local_build"
+    assert metadata.is_tag is False
+    assert metadata.pr_number is None
+    assert metadata.baseline_label is None
+
+
+@patch("spl_core.test_utils.artifacts_archiver.SubprocessExecutor")
+def test_get_git_metadata_handles_failed_git_commands(mock_subprocess, monkeypatch):
+    """When git commands fail (non-zero return code), all metadata fields stay None."""
+    for env_var in ["GIT_COMMIT", "GIT_URL"]:
+        monkeypatch.delenv(env_var, raising=False)
+    mock_subprocess.return_value.execute.return_value = MagicMock(returncode=1, stdout="")
+
+    metadata = ArtifactsArchiver._get_git_metadata()
+
+    assert metadata.commit_id is None
+    assert metadata.commit_message is None
+    assert metadata.repository_url is None
+
+
+def test_update_artifacts_json_raises_valueerror_on_os_error(sample_artifacts_json):
+    """An OSError while reading artifacts.json is wrapped in a ValueError."""
+    with patch("builtins.open", side_effect=OSError("disk error")):
+        with pytest.raises(ValueError, match=r"Could not read artifacts\.json"):
+            ArtifactsArchiver().update_artifacts_json("cat", {"a": "b"}, sample_artifacts_json)
+
+
+def test_list_archives_returns_registered_names(test_dir):
+    """list_archives returns the names of all registered archives."""
+    archiver = ArtifactsArchiver()
+    archiver.add_archive(test_dir / "out", "a.7z")
+    archiver.add_archive(test_dir / "out", "b.7z", archive_name="second")
+
+    assert set(archiver.list_archives()) == {"default", "second"}
+
+
+def test_create_archive_convenience_raises_keyerror_for_unknown():
+    """The convenience create_archive raises KeyError for an unknown archive name."""
+    archiver = ArtifactsArchiver()
+    with pytest.raises(KeyError):
+        archiver.create_archive("unknown")

--- a/tests/unit/test_spl_build.py
+++ b/tests/unit/test_spl_build.py
@@ -171,6 +171,37 @@ def test_create_artifacts_archive_inside_spl_build(spl_build: SplBuild) -> None:
     assert dict(json.loads(archive_json.read_text())) == {"variant": "my_var", "build_kit": "defaultKit", "artifacts": expected_artifacts}
 
 
+def test_execute_returns_minus_one_when_subprocess_returns_none(spl_build: SplBuild) -> None:
+    """Test that execute returns -1 when SubprocessExecutor.execute returns None."""
+    with patch("spl_core.test_utils.spl_build.sys.platform", "win32"), mock_command_execution(return_values=None) as (_mock_constructor, mock_executor):
+        mock_executor.return_value = None
+        result = spl_build.execute(target="all")
+    assert result == -1
+
+
+def test_execute_breaks_on_failure_without_stdout(spl_build: SplBuild) -> None:
+    """Test that execute breaks and returns non-zero when stdout is empty on failure."""
+    with patch("spl_core.test_utils.spl_build.sys.platform", "win32"):
+        failure_no_stdout = MagicMock(returncode=1, stdout="")
+        with mock_command_execution(return_values=failure_no_stdout) as (_, mock_executor):
+            result = spl_build.execute(target="all")
+    assert result == 1
+    assert mock_executor.call_count == 1
+
+
+def test_create_artifacts_json_with_build_type(tmp_path_factory: pytest.TempPathFactory) -> None:
+    """Test create_artifacts_json includes build_type in JSON when set."""
+    os.chdir(tmp_path_factory.mktemp("spl_build_type"))
+    spl_build = SplBuild(variant="my_var", build_kit="prod", build_type="Debug")
+    spl_build.build_dir.mkdir(parents=True, exist_ok=True)
+
+    json_path = spl_build.create_artifacts_json([])
+    assert json_path.exists()
+
+    content = dict(json.loads(json_path.read_text()))
+    assert content.get("build_type") == "Debug"
+
+
 def test_create_artifacts_archive_outside_spl_build(spl_build: SplBuild, tmp_path: Path) -> None:
     """
     Test the creation of artifacts archive and json for artifacts outsice of the spl_build folder


### PR DESCRIPTION
… from release branches/tags

Adds branch, tag_name, and further metadata to the generated rt_upload.json properties. For release branches/tags using the variant#tag syntax, the tag is extracted into tag_name while the original branch/tag name (including the literal '#') is preserved unchanged for the deploy path and branch property.

Includes a fix for the tag name extraction in build properties.